### PR TITLE
chore: stable source date epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+# inital commit time
+# git rev-list --max-parents=0 HEAD
+# git log 94a62f341d8d8331eadc894ca54f8326616540f0 --pretty=%ct
+SOURCE_DATE_EPOCH ?= "1559497065"
 
 # Sync bldr image with Pkgfile
 BLDR ?= docker run --rm --volume $(PWD):/toolchain --entrypoint=/bldr \


### PR DESCRIPTION
Use the timestamp from repo initial commit as `SOURCE_DATE_EPOCH`

Signed-off-by: Noel Georgi <git@frezbo.dev>