### PR TITLE
chore: bump tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SOURCE_DATE_EPOCH ?= "1559497065"
 
 # Sync bldr image with Pkgfile
 BLDR ?= docker run --rm --volume $(PWD):/toolchain --entrypoint=/bldr \
-	ghcr.io/siderolabs/bldr:v0.2.0-alpha.7-1-g9d49478-frontend graph --root=/toolchain
+	ghcr.io/siderolabs/bldr:v0.2.0-alpha.8-frontend graph --root=/toolchain
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -32,9 +32,9 @@ vars:
   mpc_sha512: 3279f813ab37f47fdcc800e4ac5f306417d07f539593ca715876e43e04896e1d5bceccfb288ef2908a3f24b760747d0dbd0392a24b9b341bc3e12082e5c836ee
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.62
-  linux_sha256: 06817cde8e57cdb6dbf20eaa5122fee110024f6e8b783799c98cb65dc753f141
-  linux_sha512: e238ae6ff597d874bfa01451bd179648b82735cdae8af2d262f69557fb3d23e934de38ff2438b76af828e831d4780c6533e2b0a192a1e60f35d42bf2fe27f8df
+  linux_version: 5.15.63
+  linux_sha256: 6dd3cd1e5a629d0002bc6c6ec7e8ea96710104f38664122dd56c83dfd4eb7341
+  linux_sha512: a1b33476484b9ca7a105d07b70835ad7e7e670750e6beb428ce23fe1bd853d66cd8a1ffca9ee736a98a42b98191d290127e628d33118be971c661e2fc6faf8ca
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
Bump kernel to [5.15.63](#45)
Bump bldr to [v0.2.0-alpha.8-frontend](#46)

Signed-off-by: Noel Georgi <git@frezbo.dev>