### PR TITLE
chore: update tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SOURCE_DATE_EPOCH ?= "1559497065"
 
 # Sync bldr image with Pkgfile
 BLDR ?= docker run --rm --volume $(PWD):/toolchain --entrypoint=/bldr \
-	ghcr.io/siderolabs/bldr:v0.2.0-alpha.8-frontend graph --root=/toolchain
+	ghcr.io/siderolabs/bldr:v0.2.0-alpha.10 graph --root=/toolchain
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.2.0-alpha.8-frontend
+# syntax = ghcr.io/siderolabs/bldr:v0.2.0-alpha.10
 
 format: v1alpha2
 
@@ -32,9 +32,9 @@ vars:
   mpc_sha512: 3279f813ab37f47fdcc800e4ac5f306417d07f539593ca715876e43e04896e1d5bceccfb288ef2908a3f24b760747d0dbd0392a24b9b341bc3e12082e5c836ee
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.63
-  linux_sha256: 6dd3cd1e5a629d0002bc6c6ec7e8ea96710104f38664122dd56c83dfd4eb7341
-  linux_sha512: a1b33476484b9ca7a105d07b70835ad7e7e670750e6beb428ce23fe1bd853d66cd8a1ffca9ee736a98a42b98191d290127e628d33118be971c661e2fc6faf8ca
+  linux_version: 5.15.65
+  linux_sha256: fb44fd382f4dfcf9ab0dcbe23036bf84d81f626d0fd9839f081a9d0bd52a1c94
+  linux_sha512: 39a782a76ab4a840373bae2d7f4ef0cf1a63d60e3cd78b8515184da639badb34642abdb27677ffac0344efe187a161d2ae87ac11d78f401074c21945e0c8bbee
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
Bump kernel to [5.15.65](#45)
Bump bldr to [v0.2.0-alpha.10](#46)

Signed-off-by: Noel Georgi <git@frezbo.dev>