### PR TITLE
chore: disable drone slack pipeline for renovate

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -104,9 +104,6 @@ trigger:
     exclude:
       - renovate/*
       - dependabot/*
-  status:
-    - success
-    - failure
 
 depends_on:
   - default


### PR DESCRIPTION
The slack trigger was already having status set in the step itself, so remove that and only use the trigger.

Signed-off-by: Noel Georgi <git@frezbo.dev>