### PR TITLE
chore: bump deps

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -32,9 +32,9 @@ vars:
   mpc_sha512: 3279f813ab37f47fdcc800e4ac5f306417d07f539593ca715876e43e04896e1d5bceccfb288ef2908a3f24b760747d0dbd0392a24b9b341bc3e12082e5c836ee
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.74
-  linux_sha256: 2c1539a2f85b835c36c4a07c8270b52b0bec38fdda7339477d07f0c3af8c4265
-  linux_sha512: fe65228eacf7ed9ccbcd96c84a11d5f9c62aee9eefaf7cdbc05bac2d700a4356a8a856d4d756358c28068505903ea419fc03a12a5add1a5890c9adf61fe80b80
+  linux_version: 5.15.76
+  linux_sha256: 9007a020c419e3625b980e361be09f70ebd99e156ccb66129a981483d065d57f
+  linux_sha512: de8466371030827acbe44d8e62b0322f86cbcf13ea90f9540439798ad8bc730f2bd63f62b031eec2002401c81756d6e0a83070e079285e89d416a9360eb328b1
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
Bump kernel to 5.15.76

Signed-off-by: Noel Georgi <git@frezbo.dev>