### PR TITLE
chore: bump tools

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -32,9 +32,9 @@ vars:
   mpc_sha512: 3279f813ab37f47fdcc800e4ac5f306417d07f539593ca715876e43e04896e1d5bceccfb288ef2908a3f24b760747d0dbd0392a24b9b341bc3e12082e5c836ee
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.80
-  linux_sha256: 3b321a6466d2021f60ed8d4e33bba21db2f23efc2ddd2d9fb775393d9afdfd4d
-  linux_sha512: 6434e6010678dd3c15b201ad9dd12a2a6d8293522038052259fb9957346296b156aa8ef29b6b7207de3ce4ffdb3af41bbef4255a9f73971eb15a2513c9901fb3
+  linux_version: 5.15.81
+  linux_sha256: 8f885cdebd754d6e63b920cf6c3e5713e91bbf5f52e9d99eb0054ef7e8f096ab
+  linux_sha512: 5a4cae2ee07ce73518b2f66bfb1b1f9f9aa5442ab5c5714c9bbe531cd721717810f3a0fe2a2cbbb033981bc535802fb07bd935682bfd6cae71349178a77b8319
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
Bump kernel headers to 5.15.81

Signed-off-by: Noel Georgi <git@frezbo.dev>