### PR TITLE
chore: bump linux and mpc version

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -27,14 +27,14 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
-  mpc_version: 1.2.1
-  mpc_sha256: 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
-  mpc_sha512: 3279f813ab37f47fdcc800e4ac5f306417d07f539593ca715876e43e04896e1d5bceccfb288ef2908a3f24b760747d0dbd0392a24b9b341bc3e12082e5c836ee
+  mpc_version: 1.3.0
+  mpc_sha256: 0e3b12181d37207230f5a7a7ddcfc22abfc5fc9c05825e1a65401a489a432a2a
+  mpc_sha512: 9c18b24f7542dc1dc5e10cf58fd242e73d79a9dc3619c3f08d52aed75ad0e7d9e2ba2c46857717c8b921b084af2efc8c0d2d7173081af764b81c24a8971ddd9a
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 5.15.81
-  linux_sha256: 8f885cdebd754d6e63b920cf6c3e5713e91bbf5f52e9d99eb0054ef7e8f096ab
-  linux_sha512: 5a4cae2ee07ce73518b2f66bfb1b1f9f9aa5442ab5c5714c9bbe531cd721717810f3a0fe2a2cbbb033981bc535802fb07bd935682bfd6cae71349178a77b8319
+  linux_version: 5.15.82
+  linux_sha256: fceef6bb79bac494663ccde34453521fc616cd94272fd30564752b3742381b65
+  linux_sha512: b0deb17077d9254e9a6eef853cdbcb7cbdde74cafef214d25961929d02a42fd61d306e3358b17a145999a0df3565c985de6149bd078330c63508ce8ce6fb4938
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
This PR bumps kernel headers to 5.15.82 and mpc to 1.3.0. See #56 for renovate info.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>