### PR TITLE
chore: bump linux-headers to 6.1.10

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -33,9 +33,9 @@ vars:
   mpc_sha512: 4bab4ef6076f8c5dfdc99d810b51108ced61ea2942ba0c1c932d624360a5473df20d32b300fc76f2ba4aa2a97e1f275c9fd494a1ba9f07c4cb2ad7ceaeb1ae97
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.7
-  linux_sha256: 4ab048bad2e7380d3b827f1fad5ad2d2fc4f2e80e1c604d85d1f8781debe600f
-  linux_sha512: 8b9bb3fbbea2d61314145cf6e4e1140372821a1e9ff79c4da363039c54fe73481106a5a85df0141dd449f4a21e946093a7430b14896b601c5a8b1f776107b35c
+  linux_version: 6.1.10
+  linux_sha256: 0be2919ba91cf5873a4cb4d429de78aad0469120d624e333a43b4b011d74d19d
+  linux_sha512: 7bec1d76ecafd89fdb13bc7c9c69b4f378e41b29aed33c302b235540f40f1d5e6b3c653d2dea83c2d03408e324ffa73ff3dcc7c47c685572719d62bc66a06a1d
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
This PR bumps linux-headers.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
