### PR TITLE
chore: bump deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,12 @@
     "packageRules": [
         {
             "matchPackageNames": [
+                "git://sourceware.org/git/binutils-gdb.git"
+            ],
+            "versioning": "regex:^(?<major>\\d+)_(?<minor>\\d+)_?(?<patch>\\d+)?$"
+        },
+        {
+            "matchPackageNames": [
                 "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
             ],
             "allowedVersions": "<= 6.1"

--- a/Pkgfile
+++ b/Pkgfile
@@ -6,7 +6,7 @@ vars:
   BOOTSTRAP: /bootstrap
 
   # upgrade once pahole > 1.24 is released, fix is here: https://git.kernel.org/pub/scm/devel/pahole/pahole.git/commit/?h=next&id=bcc648a10cbcd0b96b84ff7c737d56ce70f7b501
-  # renovate: datasource=git-tags extractVersion=^binutils-(?<version>.*)$ versioning=loose depName=git://sourceware.org/git/binutils-gdb.git
+  # renovate: datasource=git-tags extractVersion=^binutils-(?<version>.*)$ depName=git://sourceware.org/git/binutils-gdb.git
   binutils_version: 2_39
   binutils_sha256: 645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
   binutils_sha512: 68e038f339a8c21faa19a57bbc447a51c817f47c2e06d740847c6e9cc3396c025d35d5369fa8c3f8b70414757c89f0e577939ddc0d70f283182504920f53b0a3
@@ -33,9 +33,9 @@ vars:
   mpc_sha512: 4bab4ef6076f8c5dfdc99d810b51108ced61ea2942ba0c1c932d624360a5473df20d32b300fc76f2ba4aa2a97e1f275c9fd494a1ba9f07c4cb2ad7ceaeb1ae97
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.19
-  linux_sha256: 9e991c6e5f6c1ca45eea98c55e82ef6ae3dccc73b3e8a655c8665e585f5a8647
-  linux_sha512: 06e714a70b6014a4f56b551952db899a526b9b3f7fdb11ca0f354d99e65fff1be9a3bc9522af98a93753568266233eff2f5e6f032921293ca2802587ff866ffd
+  linux_version: 6.1.20
+  linux_sha256: 76322de8c01a3c63b42c4d1e9b9e7d1897ddb91276e10d73d1f9df3562f031f0
+  linux_sha512: 1b2660fa5464410649b2d78d08cc060de4eb38bcb158154e74fee3383cae3ff4cc373235e874eceeac3abfda9689571f3b3aed8ad2ac82ec2975e21688458a9b
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.3


### PR DESCRIPTION
Bump dependencies and drop versioning `loose`, instead use proper `matchpackageNames`.