### PR TITLE
feat: update Linux headers to 6.1.42

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -32,9 +32,9 @@ vars:
   mpc_sha512: 4bab4ef6076f8c5dfdc99d810b51108ced61ea2942ba0c1c932d624360a5473df20d32b300fc76f2ba4aa2a97e1f275c9fd494a1ba9f07c4cb2ad7ceaeb1ae97
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.1.28
-  linux_sha256: 7a094c1428b20fef0b5429e4effcc6ed962a674ac6f04e606d63be1ddcc3a6f0
-  linux_sha512: 7215e62df10847e8bce432880e0756e8a5f56eb8b8abb54f9e1eb8871ce7bd56d765be0f9a40a8dae4d135b2f9a0dab7f6b3d2691d73b0c47f05811194dee8bd
+  linux_version: 6.1.42
+  linux_sha256: aaf8261b551c8b76b81eab8780b446e88cea4d551ae517ac3a9b2dbdbd381ed3
+  linux_sha512: b3a0c682bb2234c3ec36f6302f4b39dfd501e667c39d10e2f0994b3d3dfbdc461728686d4d451b798173a76fe2ae24d8a6ab43bf869e9291d1111975405db22c
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.4


### PR DESCRIPTION
Bumping for the upcoming Talos 1.5 release.