### PR TITLE
chore: bump gcc

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -11,9 +11,9 @@ vars:
   binutils_sha512: 5df45d0bd6ddabdce4f35878c041e46a92deef01e7dea5facc97fd65cc06b59abc6fba0eb454b68e571c7e14038dc823fe7f2263843e6e627b7444eaf0fe9374
 
   # renovate: datasource=git-tags extractVersion=^releases/gcc-(?<version>.*)$ depName=git://gcc.gnu.org/git/gcc.git
-  gcc_version: 12.3.0
-  gcc_sha256: 949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b
-  gcc_sha512: 8fb799dfa2e5de5284edf8f821e3d40c2781e4c570f5adfdb1ca0671fcae3fb7f794ea783e80f01ec7bfbf912ca508e478bd749b2755c2c14e4055648146c204
+  gcc_version: 13.2.0
+  gcc_sha256: e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da
+  gcc_sha512: d99e4826a70db04504467e349e9fbaedaa5870766cda7c5cab50cdebedc4be755ebca5b789e1232a34a20be1a0b60097de9280efe47bdb71c73251e30b0862a2
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpfr/mpfr.git
   mpfr_version: 4.2.1


### PR DESCRIPTION
Previous commit does not contain gcc 13.2.0 like it claims. Fixing it.