### PR TITLE
backport: fix: add elf.h patch for new typedefs

### DIFF
--- a/musl/patches/elf.h-add-typedefs.patch
+++ b/musl/patches/elf.h-add-typedefs.patch
@@ -1,0 +1,30 @@
+https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/musl/0001-elf.h-add-typedefs-for-Elf-_Relr.patch
+
+From 981144ebc9ff30b085af107f1337543de7b0bf94 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Mon, 6 Nov 2023 12:29:16 +0100
+Subject: [PATCH] elf.h: add typedefs for Elf*_Relr
+
+Add typedefs for Elf32_Relr and Elf64_relr as a follow-up to commit
+d32dadd60efb (ldso: support DT_RELR relative relocation format)
+---
+ include/elf.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/elf.h b/include/elf.h
+index 23f2c4bc..aa186d9d 100644
+--- a/include/elf.h
++++ b/include/elf.h
+@@ -32,6 +32,9 @@ typedef uint16_t Elf64_Section;
+ typedef Elf32_Half Elf32_Versym;
+ typedef Elf64_Half Elf64_Versym;
+ 
++typedef Elf32_Word Elf32_Relr;
++typedef Elf64_Xword Elf64_Relr;
++
+ #define EI_NIDENT (16)
+ 
+ typedef struct {
+-- 
+2.42.1
+

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -17,6 +17,7 @@ steps:
         tar -xzf musl.tar.gz --strip-components=1
 
         patch -p1 < /pkg/patches/revert-faccessat2.patch
+        patch -p1 < /pkg/patches/elf.h-add-typedefs.patch
 
         mkdir build
         cd build


### PR DESCRIPTION
Required for updated stuff in `tools`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit cc75d0e9b45cd61eefa38c803ca1525e03889b30)