### PR TITLE
chore: revert musl

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -37,9 +37,9 @@ vars:
   linux_sha512: 7453d9ae753345e9312ad01da7805f68c1fb04f33aaec58ac3ba08e4b7af132c19e1822d8635fb747eb2d72cc8d89c89f3e5b7ff2e2207903cb2eb8b7dc5e884
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
-  musl_version: 1.2.5
-  musl_sha256: a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4
-  musl_sha512: 7bb7f7833923cd69c7a1a9b8a5f1784bfd5289663eb6061dcd43d583e45987df8a68a1be05d75cc1c88a3f5b610653d1a70f4a9cff4d8f7fd41ae73ee058c17c
+  musl_version: 1.2.4
+  musl_sha256: 7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039
+  musl_sha512: 498ec5d7941194a8806f4d42f0f6d218c862996ef1398b737d0d06995e0b7a6574b240a48088f6b84016b14b2776fe463f829dcb11149cdfc1023d496b235c55
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/toolchain


### PR DESCRIPTION
Revert musl to 1.2.4. Musl 1.2.5 causes a segmentation fault with `depmod`.