### PR TITLE
fix: enable default PIE build mode

### DIFF
--- a/gcc/pkg.yaml
+++ b/gcc/pkg.yaml
@@ -76,6 +76,7 @@ steps:
         --enable-libstdcxx-time \
         --enable-checking=release \
         --enable-fully-dynamic-string \
+        --enable-default-pie \
         --disable-symvers \
         --disable-gnu-indirect-function \
         --disable-libmudflap \


### PR DESCRIPTION
Allows to build position-independent static binaries in the end.