### PR TITLE
fix: add close_range to musl libc

### DIFF
--- a/musl/patches/close-range.patch
+++ b/musl/patches/close-range.patch
@@ -1,0 +1,49 @@
+https://inbox.vuxu.org/musl/20230901135733.GZ4163@brightrain.aerifal.cx/T/#mb470e2a6e72ed6f659b2d87bfa39eaac72057d4e
+
+From: Natanael Copa @ 2023-09-01 14:58 UTC (permalink / raw)
+  To: musl; +Cc: Natanael Copa
+
+close_range() is a syscall present in FreeBSD 8.0 and Linux 5.9. glibc
+2.34 added a wrapper.
+
+Expose it under _GNU_SOURCE similar to what GNU libc does. Also expose
+it under _BSD_SOURCE since it is also a FreeBSD function.
+---
+
+v2: use syscall without __syscall_ret
+
+ include/unistd.h        | 3 +++
+ src/linux/close_range.c | 8 ++++++++
+ 2 files changed, 11 insertions(+)
+ create mode 100644 src/linux/close_range.c
+
+diff --git a/include/unistd.h b/include/unistd.h
+index 5bc7f798..d89e3d4c 100644
+--- a/include/unistd.h
++++ b/include/unistd.h
+@@ -161,6 +161,9 @@ unsigned ualarm(unsigned, unsigned);
+ #define L_INCR 1
+ #define L_XTND 2
+ int brk(void *);
++#define CLOSE_RANGE_UNSHARE	(1U << 1)
++#define CLOSE_RANGE_CLOEXEC	(1U << 2)
++int close_range(unsigned int, unsigned int, int);
+ void *sbrk(intptr_t);
+ pid_t vfork(void);
+ int vhangup(void);
+diff --git a/src/linux/close_range.c b/src/linux/close_range.c
+new file mode 100644
+index 00000000..3f1378a0
+--- /dev/null
++++ b/src/linux/close_range.c
+@@ -0,0 +1,8 @@
++#define _GNU_SOURCE
++#include <unistd.h>
++#include "syscall.h"
++
++int close_range(unsigned int first, unsigned int last, int flags)
++{
++	return syscall(SYS_close_range, first, last, flags);
++}
+--
+2.42.0

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -21,6 +21,7 @@ steps:
         tar -xzf musl.tar.gz --strip-components=1
 
         patch -p1 < /pkg/patches/handle-aux-at-base.patch
+        patch -p1 < /pkg/patches/close-range.patch
 
         mkdir build
         cd build


### PR DESCRIPTION
This fixes fakeroot spinning on CPU forever.

See https://salsa.debian.org/clint/fakeroot/-/commit/80f50cd235f146ffc549018691aafc67277f0076