### PR TITLE
fix: avoid breaking usrmerge, disable multilib

### DIFF
--- a/gcc/pkg.yaml
+++ b/gcc/pkg.yaml
@@ -41,6 +41,7 @@ steps:
         --build=${BUILD} \
         --host=${HOST} \
         --prefix=/usr \
+        --libdir=/usr/lib \
         --disable-multilib \
         --disable-nls \
         --enable-shared \
@@ -72,6 +73,8 @@ steps:
         cd build
         make DESTDIR=/rootfs install-strip
         ln -sv gcc /rootfs/usr/bin/cc
+        mv /rootfs/usr/lib64/* /rootfs/usr/lib/
+        rm -rf /rootfs/usr/lib64
 finalize:
   - from: /rootfs
     to: /

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -33,6 +33,13 @@ steps:
       - |
         cd build
         make DESTDIR=/rootfs install
+        ARCH=$(uname -m)
+        mkdir -p /rootfs/usr/bin /rootfs/usr/lib
+        rm -rf /rootfs/lib
+        ln -sf /usr/lib/ld-musl-${ARCH}.so.1 /rootfs/usr/bin/ldd
+        mv -f /rootfs/usr/lib/libc.so /rootfs/usr/lib/ld-musl-${ARCH}.so.1
+        ln -sf ld-musl-${ARCH}.so.1 /rootfs/usr/lib/libc.musl-${ARCH}.so.1
+        ln -sf /usr/lib/ld-musl-${ARCH}.so.1 /rootfs/usr/lib/libc.so
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
We only build 64-bit, and usrmerge should be used to avoid needing extra env variables.

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
