### PR TITLE
chore: rekres to unify buildkits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T18:33:49Z by kres fcff05e.
+# Generated on 2025-03-07T09:24:25Z by kres e2c7efe-dirty.
 
 name: default
 concurrency:
@@ -31,15 +31,6 @@ jobs:
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     outputs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
-    services:
-      buildkitd:
-        image: moby/buildkit:v0.18.2
-        options: --privileged
-        ports:
-          - 1234:1234
-        volumes:
-          - /var/lib/buildkit/${{ github.repository }}:/var/lib/buildkit
-          - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: gather-system-info
         id: system-info
@@ -79,7 +70,7 @@ jobs:
             - endpoint: tcp://buildkit-arm64.ci.svc.cluster.local:1234
               platforms: linux/arm64
           driver: remote
-          endpoint: tcp://127.0.0.1:1234
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
       - name: Build
         if: github.event_name == 'pull_request'
         run: |
@@ -127,15 +118,6 @@ jobs:
     if: contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')
     needs:
       - default
-    services:
-      buildkitd:
-        image: moby/buildkit:v0.18.2
-        options: --privileged
-        ports:
-          - 1234:1234
-        volumes:
-          - /var/lib/buildkit/${{ github.repository }}:/var/lib/buildkit
-          - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: gather-system-info
         id: system-info
@@ -175,7 +157,7 @@ jobs:
             - endpoint: tcp://buildkit-arm64.ci.svc.cluster.local:1234
               platforms: linux/arm64
           driver: remote
-          endpoint: tcp://127.0.0.1:1234
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
       - name: reproducibility-test
         run: |
           make reproducibility-test

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T18:33:49Z by kres fcff05e.
+# Generated on 2025-03-07T09:24:25Z by kres e2c7efe-dirty.
 
 name: weekly
 concurrency:
@@ -14,15 +14,6 @@ jobs:
     runs-on:
       - self-hosted
       - pkgs
-    services:
-      buildkitd:
-        image: moby/buildkit:v0.18.2
-        options: --privileged
-        ports:
-          - 1234:1234
-        volumes:
-          - /var/lib/buildkit/${{ github.repository }}:/var/lib/buildkit
-          - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: gather-system-info
         id: system-info
@@ -62,7 +53,7 @@ jobs:
             - endpoint: tcp://buildkit-arm64.ci.svc.cluster.local:1234
               platforms: linux/arm64
           driver: remote
-          endpoint: tcp://127.0.0.1:1234
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
       - name: reproducibility-test
         run: |
           make reproducibility-test


### PR DESCRIPTION
Use same buildkit for all builds.