### PR TITLE
feat: add a parallel build of Go 1.23

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -34,6 +34,10 @@ vars:
   golang_sha256: 9dc77ffadc16d837a1bf32d99c624cb4df0647cee7b119edd9e7b1bcc05f2e00
   golang_sha512: 6366a32f6678e7908b138f62dafeed96f7144b3b93505e75fba374b33727da8b1d087c1f979f493382b319758ebfcbeb30e9d7dadcb2923b628c8abe7db41c6f
 
+  golang123_version: 1.23.8
+  golang123_sha256: 0ca1f1e37ea255e3ce283af3f4e628502fb444587da987a5bb96d6c6f15930d4
+  golang123_sha512: 8e352a01484c168894026080ee4501180e327d734fb3d892ab17daac193964fcd5fd90033c9cf86d6ffe8b7e4da64bda83ba4501a6c05919bcefbe9e2467c771
+
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1
   mpc_sha256: ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8

--- a/golang123/pkg.yaml
+++ b/golang123/pkg.yaml
@@ -1,0 +1,41 @@
+name: golang123
+variant: scratch
+dependencies:
+  - image: "{{ .stagex_prefix }}/core-busybox:{{ .stagex_busybox_version }}@sha256:{{ .stagex_busybox_sha256 }}"
+  - image: "{{ .stagex_prefix }}/core-go:{{ .stagex_go_version }}@sha256:{{ .stagex_go_sha256 }}"
+steps:
+  - sources:
+      - url: https://dl.google.com/go/go{{ .golang123_version }}.src.tar.gz
+        destination: go.src.tar.gz
+        sha256: "{{ .golang123_sha256 }}"
+        sha512: "{{ .golang123_sha512 }}"
+
+    env:
+      GOROOT_FINAL: '/rootfs/go123'
+      GOROOT: '/go123'
+
+    prepare:
+      - tar -xzf go.src.tar.gz --strip-components=1
+      - rm go.src.tar.gz
+
+    build:
+      - cd src && sh make.bash
+    install:
+      - rm -rf pkg/obj
+      - rm -rf pkg/bootstrap
+      - rm -f pkg/tool/*/api
+      - |
+        find src \( -type f -a -name "*_test.go" \) \
+        -exec rm -rf \{\} \+
+      - |
+        find src \( -type d -a -name "testdata" \) \
+        -exec rm -rf \{\} \+
+      - |
+        find src -type f -a \( -name "*.bash" -o -name "*.rc" -o -name "*.bat" \) \
+        -exec rm -rf \{\} \+
+
+      - mkdir -p "${GOROOT_FINAL}"
+      - mv * "${GOROOT_FINAL}"
+finalize:
+  - from: /rootfs
+    to: /

--- a/toolchain/pkg.yaml
+++ b/toolchain/pkg.yaml
@@ -8,6 +8,7 @@ dependencies:
   - stage: toolchain-musl
   - stage: make
   - stage: golang
+  - stage: golang123
 steps:
   - build:
     - |


### PR DESCRIPTION
Our toolchain contains Go 1.24, build in parallel Go 1.23.8.

It looks like https://github.com/siderolabs/talos/issues/10855 is caused by Go 1.24, as Talos conformance tests started failing on the day Go was updated to 1.24, and also regression testing shows no issues with contianerd built with Go 1.23.8.

Also, containerd upstream is being built/tested with Go 1.23.8 only.