### PR TITLE
feat: update Go to 1.24.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -30,9 +30,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.24.3
-  golang_sha256: 229c08b600b1446798109fae1f569228102c8473caba8104b6418cb5bc032878
-  golang_sha512: 05d19372fb923eeea19395b4de569d2ecfec7fadf2d8236d47cd667982de51c569e9816372cb79e32166553f9bcbe68f7bc2a6ded5655809b1caf5bd941011e7
+  golang_version: 1.24.4
+  golang_sha256: 5a86a83a31f9fa81490b8c5420ac384fd3d95a3e71fba665c7b3f95d1dfef2b4
+  golang_sha512: b785583fc53d62094b2de793a0e3281a26d2de17897a35b378fc2d13cb912ca473c37a7bae54a50660141809d5d0a70a97663d406cf30d7f0221ecbb5ffddec6
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1


### PR DESCRIPTION
```
We have just released Go versions 1.24.4 and 1.23.10, minor point releases.

These minor releases include 3 security fixes following the security policy:

net/http: sensitive headers not cleared on cross-origin redirect

Proxy-Authorization and Proxy-Authenticate headers persisted on cross-origin redirects potentially leaking sensitive information.

Thanks to Takeshi Kaneko (GMO Cybersecurity by Ierae, Inc.) for reporting this issue.

This is CVE-2025-4673 and Go issue https://go.dev/issue/73816.

os: inconsistent handling of O_CREATE|O_EXCL on Unix and Windows

os.OpenFile(path, os.O_CREATE|O_EXCL) behaved differently on Unix and Windows systems when the target path was a dangling symlink. On Unix systems, OpenFile with O_CREATE and O_EXCL flags never follows symlinks. On Windows, when the target path was a symlink to a nonexistent location, OpenFile would create a file in that location.

OpenFile now always returns an error when the O_CREATE and O_EXCL flags are both set and the target path is a symlink.

Thanks to Junyoung Park and Dong-uk Kim of KAIST Hacking Lab for discovering this issue.

This is CVE-2025-0913 and Go issue https://go.dev/issue/73702.

crypto/x509: usage of ExtKeyUsageAny disables policy validation

Calling Verify with a VerifyOptions.KeyUsages that contains ExtKeyUsageAny unintentionally disabledpolicy validation. This only affected certificate chains which contain policy graphs, which are rather uncommon.

Thanks to Krzysztof Skrzętnicki (@Tener) of Teleport for reporting this issue.

This is CVE-2025-22874 and Go issue https://go.dev/issue/73612.
```