### PR TITLE
chore: update bldr, fix musl name in SBOM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-15T10:21:30Z by kres c691b83.
+# Generated on 2025-07-15T12:52:26Z by kres b869533.
 
 # common variables
 
@@ -25,7 +25,7 @@ SOURCE_DATE_EPOCH := $(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)
 
 # sync bldr image with pkgfile
 
-BLDR_RELEASE := v0.5.0
+BLDR_RELEASE := v0.5.1
 BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)
 BLDR := docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.5.0
+# syntax = ghcr.io/siderolabs/bldr:v0.5.1
 
 format: v1alpha2
 

--- a/toolchain-musl/pkg.yaml
+++ b/toolchain-musl/pkg.yaml
@@ -44,6 +44,7 @@ steps:
         ln -sf /usr/lib/ld-musl-${ARCH}.so.1 /rootfs/usr/lib/libc.so
     sbom:
       outputPath: /rootfs/usr/share/spdx/musl.spdx.json
+      name: musl
       version: {{ .musl_version }}
       cpes:
         - cpe:2.3:a:musl-libc:musl:{{ .musl_version }}:*:*:*:*:*:*:*


### PR DESCRIPTION
Now we have overrides for package names, so we can drop toolchain- or
tools- prefixes.

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
