### PR TITLE
feat: update Go to 1.24.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -30,9 +30,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.24.5
-  golang_sha256: 74fdb09f2352e2b25b7943e56836c9b47363d28dec1c8b56c4a9570f30b8f59f
-  golang_sha512: 917cd6ac83e3370227da40f8490697e8638847e9279ed1806044a173d3b52829c67c429990db92d8aadcfba6a37bfc00114c1ecec3ac387a781bb7edc8dcab22
+  golang_version: 1.24.6
+  golang_sha256: e1cb5582aab588668bc04c07de18688070f6b8c9b2aaf361f821e19bd47cfdbd
+  golang_sha512: 65f535c722f4a0f6111c9ed829677621e456a5bc969ccb99009da1ade096b2b1a648a44ccfa913543677c220baeaf1afe634ba8ba165d9474ac9433ac249c914
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1


### PR DESCRIPTION
These minor releases include 2 security fixes following the security policy: os/exec: LookPath may return unexpected paths

If the PATH environment variable contains paths which are executables (rather than just directories), passing certain strings to LookPath ("", ".", and ".."), can result in the binaries listed in the PATH being unexpectedly returned.

Thanks to Olivier Mengué for reporting this issue.

This is CVE-2025-47906 and Go issue https://go.dev/issue/74466.

database/sql: incorrect results returned from Rows.Scan

Cancelling a query (e.g. by cancelling the context passed to one of the query methods) during a call to the Scan method of the returned Rows can result in unexpected results if other queries are being made in parallel. This can result in a race condition that may overwrite the expected results with those of another query, causing the call to Scan to return either unexpected results from the other query or an error.

We believe this affects most database/sql drivers.

Thanks to Spike Curtis from Coder for reporting this issue.

This is CVE-2025-47907 and https://go.dev/issue/74831.