### PR TITLE
fix: set bldr version in shebang

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.5.3
+# syntax = ghcr.io/siderolabs/bldr:v0.5.4
 
 format: v1alpha2
 


### PR DESCRIPTION
I've missed the shebang in Pkgfile, here's the fix

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
