### PR TITLE
feat: update linux-headers to 6.17

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,7 +62,7 @@
             ]
         },
         {
-            "allowedVersions": "<= 6.16",
+            "allowedVersions": "<= 6.17",
             "matchPackageNames": [
                 "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
             ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-19T05:17:50Z by kres 065ec4c.
+# Generated on 2025-10-01T12:28:48Z by kres bc281a9.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -106,7 +106,7 @@ jobs:
           make release-notes
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: crazy-max/ghaction-github-release@v2
+        uses: softprops/action-gh-release@v2
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -14,4 +14,4 @@ spec:
       versioning: 'regex:^(?<major>\d+)_(?<minor>\d+)_?(?<patch>\d+)?$'
     - matchPackageNames:
         - git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-      allowedVersions: "<= 6.16"
+      allowedVersions: "<= 6.17"

--- a/Pkgfile
+++ b/Pkgfile
@@ -40,9 +40,9 @@ vars:
   mpc_sha512: 4bab4ef6076f8c5dfdc99d810b51108ced61ea2942ba0c1c932d624360a5473df20d32b300fc76f2ba4aa2a97e1f275c9fd494a1ba9f07c4cb2ad7ceaeb1ae97
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.16.7
-  linux_sha256: 5be3daa1f9427b1bdb34c4894d9c1adfac38cff674376fe0611a3065729a1a81
-  linux_sha512: d9091bdcb6a82eb4eab3065314122b178f763173c084c9b16dd87de7ec9ba0c007a2cdfa700af9fc5a212f87686a053dc13eaa71912a589b3955686178c8e48b
+  linux_version: 6.17
+  linux_sha256: 9b607166a1c999d8326098121222feb080a20a3253975fcdfa2de96ba7f757a7
+  linux_sha512: 063999d7b819970657f6b7713fdb4173da2065ffdeed7cae197026dbb1edfd7f1d50374f073a1e19ef9686539594824ff6ecb8a930d97c4f272cb12f1c6d8355
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.5

--- a/linux-headers/pkg.yaml
+++ b/linux-headers/pkg.yaml
@@ -4,7 +4,7 @@ dependencies:
   - stage: bootstrap-c-toolchain
 steps:
   - sources:
-      - url: https://cdn.kernel.org/pub/linux/kernel/v{{ regexReplaceAll ".\\d+\\.\\d+$" .linux_version "${1}" }}.x/linux-{{ .linux_version }}.tar.xz
+      - url: https://cdn.kernel.org/pub/linux/kernel/v{{ regexReplaceAll "(\\d+)(.\\d+)(\\.\\d+)?$" .linux_version "${1}" }}.x/linux-{{ .linux_version }}.tar.xz
         destination: linux.tar.xz
         sha256: "{{ .linux_sha256 }}"
         sha512: "{{ .linux_sha512 }}"


### PR DESCRIPTION
Also rekres and update regex to match one in pkgs, so that Linux tags
without point versions can be parsed.

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
