### PR TITLE
feat: update Go to 1.26.2

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -30,9 +30,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.26.1
-  golang_sha256: 3172293d04b209dc1144698e7ba13f0477f6ba8c5ffd0be66c20fdbc9785dfbb
-  golang_sha512: 7bab2a762b4aff1c2c3a3cf3ad20bce63fabff28c7ff63b18cb8b0ce427a7bc1781cfd3fa291f4bff499247b1f0fd56f1698bb19bc7c1be7d7d2f38716438d41
+  golang_version: 1.26.2
+  golang_sha256: 2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b
+  golang_sha512: 370773727c0e6fbf0acd534726938aaaa03ff785f0634c258c94a7a896e9a27acc0ba57120967f711a942e9e275cec46251a194d6f84ba15f28b5dcf0efed673
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1


### PR DESCRIPTION
Update Go to 1.26.2

See:

We have just released Go versions 1.26.2 and 1.25.9, minor point releases.

These releases include 10 security fixes following the security policy:

os: Root.Chmod can follow symlinks out of the root on Linux

On Linux, if the target of Root.Chmod is replaced with a symlink while the chmod operation is in progress, Chmod could operate on the target of the symlink, even when the target lies outside the root.

The Linux fchmodat syscall silently ignores the AT_SYMLINK_NOFOLLOW flag, which Root.Chmod uses to avoid symlink traversal. Root.Chmod checks its target before acting and returns an error if the target is a symlink lying outside the root, so the impact is limited to cases where the target is replaced with a symlink between the check and operation.

On Linux, Root.Chmod now uses the fchmodat2 syscall when available, and an workaround using /proc/self/fd otherwise.

Thanks to Uuganbayar Lkhamsuren for reporting this issue.

This is CVE-2026-32282 and Go issue https://go.dev/issue/78293.

html/template: JS template literal context incorrectly tracked

Context was not properly tracked across template branches for JS template literals, leading to possibly incorrect escaping of content when branches were used.

Additionally template actions within JS template literals did not properly track the brace depth, leading to incorrect escaping being applied.

These issues could cause actions within JS template literals to be incorrectly or improperly escaped, leading to XSS vulnerabilities.

This only affects templates that use template actions within JS template literals.

This is CVE-2026-32289 and Go issue https://go.dev/issue/78331.

crypto/x509: excluded DNS constraints not properly applied to wildcard domains

When verifying a certificate chain containing excluded DNS constraints, these constraints are not correctly applied to wildcard DNS SANs which use a different case than the constraint.

For example, if a certificate contains the DNS name "*.example.com" and the excluded DNS name "EXAMPLE.COM", the constraint will not be applied.

This only affects validation of otherwise trusted certificate chains, issued by a root CA in the VerifyOptions.Roots CertPool, or in the system certificate pool.

This issue only affects Go 1.26.

Thank you to Riyas from Saintgits College of Engineering, k1rnt, @1seal for reporting this issue.

This is CVE-2026-33810 and Go issue https://go.dev/issue/78332.

cmd/compile: no-op interface conversion bypasses overlap checking

Previously, the compiler failed to unwrap pointers contained within a no-op interface conversion leading to an incorrect determination of a non-overlapping move.

To prevent unsafe move operations, the compiler will now unwrap all such conversions before considering a move non-overlapping.

Thank you to Jakub Ciolek - https://ciolek.dev/ for reporting this issue.

This is CVE-2026-27144 and Go issue https://go.dev/issue/78371.

cmd/compile: possible memory corruption after bound check elimination

Previously, slices and arrays accessed using induction variables were sometimes incorrectly proved in-bound. If the induction variable used for indexing were to overflow or underflow, it could allow access to memory beyond the scope of the original slice or array.

To prevent this behavior, the compiler ensures that any mutated induction variable that overflows/underflows with respect to its loop condition is not used for bound check elimination.

Thank you to Jakub Ciolek - https://ciolek.dev/ for reporting this issue.

This is CVE-2026-27143 and Go issue https://go.dev/issue/78333.

archive/tar: unbounded allocation when parsing old format GNU sparse map

tar.Reader could allocate an unbounded amount of memory when reading a maliciously-crafted archive containing a large number of sparse regions encoded in the "old GNU sparse map" format.

We now limit both the number of old GNU sparse map extension blocks, and the total number of sparse file entries, regardless of encoding.

Thanks to Colin Walters (walters@verbum.org) who initially reported this issue. Thanks also to Uuganbayar Lkhamsuren (https://github.com/uug4na) and Jakub Ciolek who additionally reported this issue.

This is CVE-2026-32288 and Go issue https://go.dev/issue/78301.

crypto/tls: multiple key update handshake messages can cause connection to deadlock

If one side of the TLS connection sends multiple key update messages post-handshake in a single record, the connection can deadlock, causing uncontrolled consumption of resources. This can lead to a denial of service.

This only affects TLS 1.3.

Thank you to Jakub Ciolek - https://ciolek.dev/ for reporting this issue.

This is CVE-2026-32283 and Go issue https://go.dev/issue/78334.

cmd/go: trust layer bypass when using cgo and SWIG

A well-crafted SWIG source file could take advantage of a file-naming convention used inside the trust
boundary of the cgo compiler. Doing so could result in arbitrary code execution during build time.

SWIG files are disallowed from using this convention.

Thank you to Juho Forsén of Mattermost for reporting this issue.

This is CVE-2026-27140 and Go issue https://go.dev/issue/78335.

crypto/x509: unexpected work during chain building

During chain building, the amount of work that is done is not correctly limited when a large number of intermediate certificates are passed in VerifyOptions.Intermediates, which can lead to a denial of service. This affects both direct users of crypto/x509 and users of crypto/tls.

Thank you to Jakub Ciolek - https://ciolek.dev/ for reporting this issue.

This is CVE-2026-32280 and Go issue https://go.dev/issue/78282.

crypto/x509: inefficient policy validation

Validating certificate chains which use policies is unexpectedly inefficient when certificates in the chain contain a very large number of policy mappings, possibly causing denial of service.

This only affects validation of otherwise trusted certificate chains, issued by a root CA in the VerifyOptions.Roots CertPool, or in the system certificate pool.

Thank you to Jakub Ciolek - https://ciolek.dev/ for reporting this issue.

This is CVE-2026-32281 and Go issue https://go.dev/issue/78281.