### PR TITLE
chore: update dependencies for 1.12.8

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -30,9 +30,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.25.9
-  golang_sha256: 0ec9ef8ebcea097aac37decae9f09a7218b451cd96be7d6ed513d8e4bcf909cf
-  golang_sha512: b1a89da9f53db56f59716814adf412f10fcb7e72aa9fa0df216ad7200082731f18b449bc669d340f59b80355e66a6e2f156567a45ffd2e138df45bf8bce8dd8f
+  golang_version: 1.25.10
+  golang_sha256: 20cf04a92e5af99748e341bc8996fa28090c9ac98765fa115ec5ddf41d7af41d
+  golang_sha512: 4a938b18d00af583d1ab8592386b8c71385997b1c8fab661549232ee84ac2f42716dc8304c38f1f462335a12048da19611bb614a7007d8201e6818a11f187487
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1


### PR DESCRIPTION
Update go to 1.25.10

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
