### PR TITLE
fix: musl cves

### DIFF
--- a/toolchain-musl/patches/CVE-2026-40200.patch
+++ b/toolchain-musl/patches/CVE-2026-40200.patch
@@ -1,5 +1,3 @@
-https://www.openwall.com/lists/musl/2026/04/10/3/1
-
 >From 228da39e38c1cae13cbe637e771412c1984dba5d Mon Sep 17 00:00:00 2001
 From: Rich Felker <dalias@aerifal.cx>
 Date: Thu, 9 Apr 2026 22:51:30 -0400

--- a/toolchain-musl/patches/CVE-2026-6042.patch
+++ b/toolchain-musl/patches/CVE-2026-6042.patch
@@ -1,5 +1,3 @@
-https://git.musl-libc.org/cgit/musl/patch/?id=67219f0130ec7c876ac0b299046460fad31caabf
-
 From 67219f0130ec7c876ac0b299046460fad31caabf Mon Sep 17 00:00:00 2001
 From: Rich Felker <dalias@aerifal.cx>
 Date: Mon, 30 Mar 2026 16:00:50 -0400

--- a/toolchain-musl/pkg.yaml
+++ b/toolchain-musl/pkg.yaml
@@ -20,8 +20,8 @@ steps:
 
         patch -p1 < /pkg/patches/handle-aux-at-base.patch
         patch -p1 < /pkg/patches/close-range.patch
-        patch -p1 < /pkg/patches/gb-iconv.patch
-        patch -p1 < /pkg/patches/qsort.patch
+        patch -p1 < /pkg/patches/CVE-2026-6042.patch
+        patch -p1 < /pkg/patches/CVE-2026-40200.patch
 
         mkdir build
         cd build


### PR DESCRIPTION
CVE-2026-6042 is the new one
CVE-2026-40200 was already in qsort, just rename to match from upstream at https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/musl