### PR TITLE
feat: bump go to 1.26.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -29,9 +29,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.26.3
-  golang_sha256: 1c646875d0aa8799133184ed57cf79ff24bdefe8c8820470602a9d3d6d9192b8
-  golang_sha512: 9c673a9ec7783a345b6294984486a5c76ba52de3eb72c95cbd68626312d100c50adb7a3ed15c93d1dc9ce9969b0f6fb4b86c87771118091cc7b0297afaf74fec
+  golang_version: 1.26.4
+  golang_sha256: 4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d
+  golang_sha512: adacc6a34ad239d98277acd2ac8da867110da0b184dbbafb82e8a06d2b7fd23434f878a8a8cd550172c21bd31ac6391d01a0bd095c9f5c1250be66b459c8de88
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.4.1


### PR DESCRIPTION
Bump Go to 1.26.4

See https://go.dev/doc/devel/release#go1.26.minor