### PR TITLE
DNM chore: Backports for 1.12 - bump Go to 1.26.4 (minor)

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -30,9 +30,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.25.11
-  golang_sha256: 7b4e5b079b3c9bc420373ca68621a296b4d13c10735d4acac4171928d70f5480
-  golang_sha512: d1fa0d267ee8ba55aacbe47562c128cccabb757dc1f5c553ac0fe70eec9edc49cf66133df6f88997c752e89f9d24b77bf4b6448f73fdd7d05f8bca88951eea26
+  golang_version: 1.26.4
+  golang_sha256: 4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d
+  golang_sha512: adacc6a34ad239d98277acd2ac8da867110da0b184dbbafb82e8a06d2b7fd23434f878a8a8cd550172c21bd31ac6391d01a0bd095c9f5c1250be66b459c8de88
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1


### PR DESCRIPTION
Currently on 1.25.11. This is blocking the upgrade of containerd to 2.3.2, since it requires Go>=1.26.3. Containerd ships patches for critical CVEs.

https://github.com/siderolabs/pkgs/pull/1588