### PR TITLE
chore: backports for 1.13.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -30,9 +30,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.26.4
-  golang_sha256: 4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d
-  golang_sha512: adacc6a34ad239d98277acd2ac8da867110da0b184dbbafb82e8a06d2b7fd23434f878a8a8cd550172c21bd31ac6391d01a0bd095c9f5c1250be66b459c8de88
+  golang_version: 1.26.5
+  golang_sha256: 495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42
+  golang_sha512: 1c1ff7bc002438e77c968155b077c51df87935d1a1a214c8750e748abe3af5cf83769eae5cfe85ca1b12a0e6fa4a0dfe4344b1023f037f206dad328607bba9f7
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1


### PR DESCRIPTION
Backports:
* https://github.com/siderolabs/toolchain/pull/212
